### PR TITLE
Use NPX for ng instead of global version

### DIFF
--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -29,7 +29,8 @@
               <target>
                 <mkdir dir="target"/>
                 <echo message="Generating frontend resource"/>
-                <exec executable="ng">
+                <exec executable="npx">
+                  <arg value="ng"/>
                   <arg value="build"/>
                   <arg value="--deployUrl"/>
                   <arg value="/${deploy.url}/"/>


### PR DESCRIPTION
Running `mvn clean install` failed for me because I don't have the Angular CLI installed globally. Using npx get Node to use the Angular CLI package in the project directory and uses the version given in "package.json".